### PR TITLE
Tick build number to 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {%set compress_type = "tar.gz" %}
 {%set hash_type = "sha256" %}
 {%set hash_val = "9fa5dcac35eefd53e25d6cd4c310d963c9f0b897641772cd6e5e7b89df7ee0b1" %}
-{%set build_num = "1" %}
+{%set build_num = "2" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This is solely to force a `py36` build for `osx`, as it seems to have been permanently lost in the mix.